### PR TITLE
(fix) Default helm_chart_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"kube-state-metrics"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"2.1.4"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"2.2.0"` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"kube-state-metrics"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.bitnami.com/bitnami"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "2.1.4"
+  default     = "2.2.0"
   description = "Version of the Helm chart"
 }
 


### PR DESCRIPTION
The current default `helm_chart_version` is set to `2.1.4` however looking at the available versions [here](https://artifacthub.io/packages/helm/bitnami/kube-state-metrics/2.2.0) looks like `2.2.0` is the oldest available version.

This fixes the issue where if someone is not providing the default version, the terraform apply failed with this error:
```
Error: could not download chart: chart "kube-state-metrics" version "2.1.4" not found in https://charts.bitnami.com/bitnami repository
```